### PR TITLE
memoを複数行入力した際にホームとプレビュー画面で改行をそのまま表示

### DIFF
--- a/src/app/home/edit.html
+++ b/src/app/home/edit.html
@@ -15,7 +15,7 @@
 <div class="previewContents">
   <p>
     <label class="inputHeading" for="memo">メモ</label>
-    <input type="text" id="memo" class="inputArea" maxlength="50" size="25" value="{{item.memo}}" placeholder="コメントを入力">
+    <textarea id="memo" class="inputArea">{{item.memo}}</textarea>
   </p>
 
   <p>

--- a/src/app/home/home.scss
+++ b/src/app/home/home.scss
@@ -10,6 +10,10 @@
 }
 */
 
+.heading__memo{
+  white-space:pre-line;
+}
+
 .list_item_title {
   margin-top: 0px;
 }

--- a/src/app/home/preview.scss
+++ b/src/app/home/preview.scss
@@ -23,6 +23,7 @@
 
 .definitionList__description{
   margin-bottom: 1em;
+  white-space:pre-line;
 }
 
 .imgPreview{


### PR DESCRIPTION
編集画面のメモ欄をinputからtextareaに戻してます。
入力された改行がホーム画面とプレビュー画面でそのまま表示されるようにしてます。